### PR TITLE
Allow execution of docker commands from within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,15 @@ ARG BORGMATIC_VERSION=1.5.8
 
 COPY --from=builder /wheels /wheels
 
-RUN apk --no-cache add borgbackup openssh-client bash \
+RUN apk add --no-cache \
+        bash \
+        borgbackup \
+        openssh-client \
     && pip3 install -f /wheels borgmatic==${BORGMATIC_VERSION} \
-    && rm -fr /var/cache/apk/* /wheels /.cache
+    && rm -fr \
+        /.cache \
+        /var/cache/apk/* \
+        /wheels
 
 COPY ./entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.6-alpine3.7
+ARG PYTHON_VERSION=3.8-alpine3.12
 
 FROM python:${PYTHON_VERSION} as builder
 ARG BORGMATIC_VERSION=1.5.8
@@ -15,6 +15,7 @@ COPY --from=builder /wheels /wheels
 RUN apk add --no-cache \
         bash \
         borgbackup \
+        docker-cli \
         openssh-client \
     && pip3 install -f /wheels borgmatic==${BORGMATIC_VERSION} \
     && rm -fr \

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ If the first argument does not start with a `-`, then it is called as an executa
 docker run --rm monachus/borgmatic borg --version
 ```
 
+## Docker Commands
+
+You can execute docker commands - e.g. triggering a container's built-in backup solution or
+start/stop a container - from borgmatic hooks if you bind mount the `/var/run/docker.sock` file
+from the host. This can be achieved by adding `-v /var/run/docker.sock:/var/run/docker.sock` to the
+example above.
+
+However, this grants complete docker-daemon access to the container and thus effectively the host
+system. Make sure to consider the security implications when evaluating this use case.
+
 # Issues
 
 Please open an issue describing the problem or requested feature. PRs are welcome.


### PR DESCRIPTION
This PR installs the `docker-cli` package to allow execution of docker commands from within the container.

Closes #1